### PR TITLE
Bump API versions that are removed in 1.22

### DIFF
--- a/charts/lsdobserve/Chart.yaml
+++ b/charts/lsdobserve/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lsdobserve
-version: "1.0.83"
+version: "1.1.0"
 appVersion: "1.0.2"
 # Disabling kubeVersion because GKE is dumb
 # kubeVersion: ">=v1.11.0"

--- a/charts/lsdobserve/crds/elastic-crds.yaml
+++ b/charts/lsdobserve/crds/elastic-crds.yaml
@@ -1,6 +1,6 @@
 # https://github.com/elastic/cloud-on-k8s/blob/master/config/crds/all-crds.yaml
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -280,7 +280,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -849,7 +849,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -1151,7 +1151,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -2440,7 +2440,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -2957,7 +2957,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/lsdobserve/templates/elastic.kibana.yaml
+++ b/charts/lsdobserve/templates/elastic.kibana.yaml
@@ -34,7 +34,7 @@ spec:
 # Kibana Ingress
 {{- if or (eq .Values.lsdobserve.clusterType "gke") (eq .Values.lsdobserve.clusterType "rancher") -}}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/charts/lsdobserve/templates/grafana.yaml
+++ b/charts/lsdobserve/templates/grafana.yaml
@@ -86,7 +86,7 @@ metadata:
 # Grafana Ingress
 {{- if or (eq .Values.lsdobserve.clusterType "gke") (eq .Values.lsdobserve.clusterType "rancher") -}}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
In 1.22, K8s removes the `apiextensions.k8s.io/v1beta1` and `extensions/v1beta1` API versions in favour of the GA versions. This PR fixes that allowing Observe to be installed on 1.22+